### PR TITLE
Correcting iOS FFI access to native library

### DIFF
--- a/lib/src/framework/native/library/open_library_strategy.dart
+++ b/lib/src/framework/native/library/open_library_strategy.dart
@@ -1,4 +1,5 @@
 import 'dart:ffi';
+import 'dart:io';
 
 import 'open_library.dart';
 
@@ -32,7 +33,9 @@ abstract class OpenLibraryStrategy {
   /// Return the opened [DynamicLibrary] on success.
   DynamicLibrary? open(String path) {
     try {
-      return DynamicLibrary.open(path);
+      return Platform.isIOS
+          ? DynamicLibrary.process()
+          : DynamicLibrary.open(path);
     } on Exception {
       return null;
     }


### PR DESCRIPTION
This PR fixed iOS embedding of this library since the changed to FFI.

Source: https://docs.flutter.dev/development/platform-integration/ios/c-interop